### PR TITLE
remove all warnings from recent rust toolchain

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -84,14 +84,7 @@ impl fmt::Display for Error {
 
 // implement the standard error trait for hexadecimal errors.
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::IoError(ref err) => err.description(),
-            Error::Parsing(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::IoError(ref err) => Some(err),
             Error::Parsing(ref err) => Some(err),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,9 +23,9 @@ pub fn intoval(c: u8) -> Result<u8, ParseHexError> {
     //   MIT/APACHE (at your option)
     // ------------------------------------------------------
     match c {
-        b'A'...b'F' => Ok(c - b'A' + 10),
-        b'a'...b'f' => Ok(c - b'a' + 10),
-        b'0'...b'9' => Ok(c - b'0'),
+        b'A'..=b'F' => Ok(c - b'A' + 10),
+        b'a'..=b'f' => Ok(c - b'a' + 10),
+        b'0'..=b'9' => Ok(c - b'0'),
         _ => {
             let val = c as char;
             Err(ParseHexError::Char { val })
@@ -38,9 +38,9 @@ pub fn intoval(c: u8) -> Result<u8, ParseHexError> {
 #[inline]
 pub fn fromval(val: u8) -> u8 {
     match val {
-        0xa...0xf => val - 0xa + b'a',
-        0x0...0x9 => val + b'0',
-        _ => panic!("value outside range 0x0...0xf"),
+        0xa..=0xf => val - 0xa + b'a',
+        0x0..=0x9 => val + b'0',
+        _ => panic!("value outside range 0x0..=0xf"),
     }
 }
 
@@ -49,9 +49,9 @@ pub fn fromval(val: u8) -> u8 {
 #[inline]
 pub fn fromvalcaps(val: u8) -> u8 {
     match val {
-        0xA...0xF => val - 0xa + b'A',
-        0x0...0x9 => val + b'0',
-        _ => panic!("value outside range 0x0...0xf"),
+        0xA..=0xF => val - 0xa + b'A',
+        0x0..=0x9 => val + b'0',
+        _ => panic!("value outside range 0x0..=0xf"),
     }
 }
 


### PR DESCRIPTION
This commit removes all the warnings that appeared when compiling the
crate with a recent toolchain version:

	rustc 1.44.1 (c7087fe00 2020-06-17)